### PR TITLE
redirect lazy users who only type "profanity.im"

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,6 @@
+<IfModule mod_rewrite.c>
+  Options +FollowSymLinks
+	RewriteEngine on
+	RewriteCond %{HTTP_HOST} ^profanity.im [NC]
+	RewriteRule ^(.*)$ http://www.profanity.im/$1 [R=301,L]
+</IfModule>


### PR DESCRIPTION
Are you running Apache James? 

I thought your website was down when I just tried "profanity.im", which I often do with websites because I’m lazy.

Anyway, if you do, if you add this to the root, this will redirect users to www if the have just tried without.
