### PR TITLE
Bump lib mesode version

### DIFF
--- a/install-all.sh
+++ b/install-all.sh
@@ -80,7 +80,6 @@ install_lib_mesode()
     echo
     git clone https://github.com/boothj5/libmesode.git
     cd libmesode
-    git checkout 0.9.1
     ./bootstrap.sh
     ./configure $@
     make


### PR DESCRIPTION
Profanity now requires 0.9.2 libmesode.

Let's pull master in the install script, and not the 0.9.1 version anymore.
Maybe the branch libstrophe-0.9.2-merge could do it to but i have not take the time to look into it.