### PR TITLE
Update other clients list and fix typo

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -142,13 +142,7 @@
         <section>
             <a name="clients"></a>
             <h4>Are there more clients like this?</h4>
-            <p>Yes, there are are several commandline clients:</p>
-            <ul>
-                <li><a href="https://www.gnu.org/software/freetalk/">freetalk</a></li>
-                <li><a href="https://mcabber.com/">mcabber</a></li>
-                <li><a href="https://poez.io">poezio</a></li>
-                <li><a href="https://xmpp.org/software/clients.html">More clients...</a></li>
-            </ul>
+            <p>Yes, there are several commandline clients: <a href="https://www.gnu.org/software/freetalk/">freetalk</a>, <a href="https://mcabber.com/">mcabber</a>, <a href="https://poez.io">poezio</a>, <a href="https://xmpp.org/software/clients.html">more clients.</a></p>
             <a href="#top"><h5>back to top</h5></a>
         </section>
     </article>


### PR DESCRIPTION
A proposal to beautify the other clients list. As comma seperated list inside the paragraph it fits nicely into the FAQ page until someone with more CSS skills can improve the list.

Also removed duplicate "are".