### PR TITLE
Remove freetalk recommendation

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -132,7 +132,7 @@
         <section>
             <a name="clients"></a>
             <h4>Are there more clients like this?</h4>
-            <p>Yes, there are several commandline clients: <a href="https://www.gnu.org/software/freetalk/">freetalk</a>, <a href="https://mcabber.com/">mcabber</a>, <a href="https://poez.io">poezio</a> and <a href="https://xmpp.org/software/clients.html">more clients</a>.</p>
+            <p>Yes, there are several commandline clients: <a href="https://mcabber.com/">mcabber</a>, <a href="https://poez.io">poezio</a> and <a href="https://xmpp.org/software/clients.html">more clients</a>.</p>
             <a href="#top"><h5>back to top</h5></a>
         </section>
     </article>


### PR DESCRIPTION
I think freetalk should not be recommended:
* No release for five years [1]
* No activity for almost three years [1]
* Unmaintained since more than a year [2]

[1]: http://git.savannah.gnu.org/cgit/freetalk.git
[2]: https://lists.gnu.org/archive/html/freetalk-dev/2018-07/msg00000.html