### PR TITLE
Switch to https links and update version numbers

### DIFF
--- a/xeps.html
+++ b/xeps.html
@@ -29,177 +29,152 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td><a href="http://www.xmpp.org/extensions/xep-0012.html" target="_blanK">XEP-0012 Last
-                                Activity</a></td>
+                        <td><a href="https://www.xmpp.org/extensions/xep-0012.html" target="_blanK">XEP-0012: Last Activity</a></td>
                         <td>2.0</td>
                         <td></td>
                     </tr>
                     <tr>
-                        <td><a href="http://www.xmpp.org/extensions/xep-0027.html" target="_blank">XEP-0027 Current
-                                Jabber OpenPGP Usage</a></td>
-                        <td>1.3</td>
-                        <td></td>
-                    </tr>
-                    <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0030.html" target="_blank">XEP-0030 Service
-                                Discovery</a></td>
-                        <td></td>
-                        <td></td>
-                    </tr>
-                    <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0045.html" target="_blank">XEP-0045 Multi-User
-                                Chat</a></td>
-                        <td></td>
-                        <td></td>
-                    </tr>
-                    <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0048.html" target="_blank">XEP-0048 Bookmarks</a>
-                        </td>
-                        <td>1.0</td>
-                        <td></td>
-                    </tr>
-                    <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0050.html" target="_blank">XEP-0050 Ad-Hoc
-                                Commands</a></td>
-                        <td>1.2.1</td>
-                        <td>Since 0.6.0. No multi-step yet</td>
-                    </tr>
-                    <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0060.html" target="_blank">XEP-0060
-                                Publish-Subscribe</a></td>
-                        <td>1.15.8</td>
-                        <td>Since 0.7.0. Used for OMEMO.</td>
-                    </tr>
-                    <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0085.html" target="_blank">XEP-0085 Chat State
-                                Notifications</a></td>
-                        <td>2.1</td>
-                        <td></td>
-                    </tr>
-                    <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0091.html" target="_blank">XEP-0091 Legacy Delayed
-                                Delivery</a></td>
+                        <td><a href="https://www.xmpp.org/extensions/xep-0027.html" target="_blank">XEP-0027: Current Jabber OpenPGP Usage</a></td>
                         <td>1.4</td>
                         <td></td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0092.html" target="_blank">XEP-0092 Software
-                                Version</a></td>
-                        <td>1.1</td>
-                        <td></td>
-                    </tr>
-                    <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0115.html" target="_blank">XEP-0115 Entity
-                                Capabilities</a></td>
+                        <td><a href="https://xmpp.org/extensions/xep-0030.html" target="_blank">XEP-0030: Service Discovery</a></td>
                         <td></td>
                         <td></td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0160.html" target="_blank">XEP-0160 Best Practices
-                                for Handling Offline Messages</a></td>
-                        <td>1.0.1</td>
+                        <td><a href="https://xmpp.org/extensions/xep-0045.html" target="_blank">XEP-0045: Multi-User Chat</a></td>
+                        <td></td>
                         <td></td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0184.html" target="_blank">XEP-0184 Message Delivery
-                                Receipts</a></td>
+                        <td><a href="https://xmpp.org/extensions/xep-0048.html" target="_blank">XEP-0048: Bookmarks</a></td>
                         <td>1.2</td>
                         <td></td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0191.html" target="_blank">XEP-0191 Blocking
-                                Command</a></td>
+                        <td><a href="https://xmpp.org/extensions/xep-0050.html" target="_blank">XEP-0050: Ad-Hoc Commands</a></td>
+                        <td>1.3.0</td>
+                        <td>Since 0.6.0. No multi-step yet.</td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://xmpp.org/extensions/xep-0060.html" target="_blank">XEP-0060: Publish-Subscribe</a></td>
+                        <td>1.15.8</td>
+                        <td>Since 0.7.0. Used for OMEMO.</td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://xmpp.org/extensions/xep-0085.html" target="_blank">XEP-0085: Chat State Notifications</a></td>
+                        <td>2.1</td>
+                        <td></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://xmpp.org/extensions/xep-0091.html" target="_blank">XEP-0091: Legacy Delayed Delivery</a></td>
+                        <td>1.4</td>
+                        <td></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://xmpp.org/extensions/xep-0092.html" target="_blank">XEP-0092: Software Version</a></td>
+                        <td>1.1</td>
+                        <td></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://xmpp.org/extensions/xep-0115.html" target="_blank">XEP-0115: Entity Capabilities</a></td>
+                        <td></td>
+                        <td></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://xmpp.org/extensions/xep-0160.html" target="_blank">XEP-0160: Best Practices for Handling Offline Messages</a></td>
+                        <td>1.0.1</td>
+                        <td></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://xmpp.org/extensions/xep-0184.html" target="_blank">XEP-0184: Message Delivery Receipts</a></td>
+                        <td>1.2</td>
+                        <td></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://xmpp.org/extensions/xep-0191.html" target="_blank">XEP-0191: Blocking Command</a></td>
                         <td>1.3</td>
                         <td></td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0199.html" target="_blank">XEP-0199 XMPP Ping</a>
+                        <td><a href="https://xmpp.org/extensions/xep-0199.html" target="_blank">XEP-0199: XMPP Ping</a>
                         </td>
                         <td>2.0.1</td>
                         <td></td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0203.html" target="_blank">XEP-0203 Delayed
-                                Delivery</a></td>
+                        <td><a href="https://xmpp.org/extensions/xep-0203.html" target="_blank">XEP-0203: Delayed Delivery</a></td>
                         <td>2.0</td>
                         <td></td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0245.html" target="_blank">XEP-0245 The /me
-                                Command</a></td>
+                        <td><a href="https://xmpp.org/extensions/xep-0245.html" target="_blank">XEP-0245: The /me Command</a></td>
                         <td>1.0</td>
                         <td></td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0249.html" target="_blank">XEP-0249 Direct MUC
-                                Invitations</a></td>
+                        <td><a href="https://xmpp.org/extensions/xep-0249.html" target="_blank">XEP-0249: Direct MUC Invitations</a></td>
                         <td>1.0</td>
                         <td></td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0256.html" target="_blank">XEP-0256 Last Activity in
-                                Presence</a></td>
+                        <td><a href="https://xmpp.org/extensions/xep-0256.html" target="_blank">XEP-0256: Last Activity in Presence</a></td>
                         <td>1.1</td>
                         <td></td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0280.html" target="_blank">XEP-0280 Message
-                                Carbons</a></td>
+                        <td><a href="https://xmpp.org/extensions/xep-0280.html" target="_blank">XEP-0280: Message Carbons</a></td>
                         <td>0.12.1</td>
                         <td></td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0308.html" target="_blank">XEP-0308 Last Message Correction</a></td>
-                        <td>1.1.0</td>
+                        <td><a href="https://xmpp.org/extensions/xep-0308.html" target="_blank">XEP-0308: Last Message Correction</a></td>
+                        <td>1.2.0</td>
                         <td>Since 0.9.0.</td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0359.html" target="_blank">XEP-0359 Unique and
-                                Stable Stanza IDs</a></td>
-                        <td>0.6.0</td>
-                        <td>Since 0.8.0. Only </origin-id> No </stanza-id> yet.</td>
+                        <td><a href="https://xmpp.org/extensions/xep-0359.html" target="_blank">XEP-0359: Unique and Stable Stanza IDs</a></td>
+                        <td>0.6.1</td>
+                        <td>Since 0.8.0. Only <pre><code></origin-id></code></pre>, no <pre><code></stanza-id></code></pre> yet.</td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0363.html" target="_blank">XEP-0363 HTTP File
-                                Upload</a></td>
-                        <td>0.9.0</td>
+                        <td><a href="https://xmpp.org/extensions/xep-0363.html" target="_blank">XEP-0363: HTTP File Upload</a></td>
+                        <td>1.0.0</td>
                         <td></td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0364.html" target="_blank">XEP-0364 Current
-                                Off-the-Record Messaging Usage</a></td>
-                        <td>0.3.1</td>
+                        <td><a href="https://xmpp.org/extensions/xep-0364.html" target="_blank"XEP-0364: Current Off-the-Record Messaging Usage</a></td>
+                        <td>0.3.2</td>
                         <td></td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0374.html" target="_blank">XEP-0374 OpenPGP
-                                for XMPP Instant Messaging</a></td>
+                        <td><a href="https://xmpp.org/extensions/xep-0374.html" target="_blank">XEP-0374: OpenPGP for XMPP Instant Messaging</a></td>
                         <td>0.2.0</td>
                         <td>Only in development version.</td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0384.html" target="_blank">XEP-0384 OMEMO
-                                Encryption</a></td>
+                        <td><a href="https://xmpp.org/extensions/xep-0384.html" target="_blank">XEP-0384: OMEMO Encryption</a></td>
                         <td>0.3.0</td>
-                        <td>Since 0.7.0</td>
+                        <td>Since 0.7.0.</td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-0392.html" target="_blank">XEP-0392 Consistent Color
-                                Generation</a></td>
+                        <td><a href="https://xmpp.org/extensions/xep-0392.html" target="_blank">XEP-0392: Consistent Color Generation</a></td>
                         <td>0.7.0</td>
-                        <td>Since 0.8.0</td>
+                        <td>Since 0.8.0.</td>
                     </tr>
                     <tr>
-                        <td><a href="http://xmpp.org/extensions/xep-xxxx.html" target="_blank">XEP-xxxx OMEMO Media sharing</a></td>
-                        <td>0.0.2</td>
-                        <td>Since 0.10.0</td>
+                        <td><a href="https://xmpp.org/extensions/xep-0454.html" target="_blank">XEP-0454: OMEMO Media sharing</a></td>
+                        <td>0.1.0</td>
+                        <td>Since 0.10.0.</td>
                     </tr>
                 </tbody>
             </table>
         </section>
     </article>
     <footer>
-        <p class="matty">site designed by <a href="http://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
+        <p class="matty">site designed by <a href="https://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
     </footer>
 </body>
 


### PR DESCRIPTION
Change HTTP to HTTPS links, change version numbers where sensible, make formatting consistent.

I only updated version numbers that had minor changes not affecting the general content of the XEP, since i have no idea what profanity really supports. Supported version numbers of

* XEP-0030
* XEP-0045
* XEP-0060
* XEP-0152
* XEP-0249
* XEP-0280

need clarification from developers.

Also i did some additional punctuation formatting changes, to make it consistent? Since there were some sort of wrap at around column 120, i can redo that to comply with coding style guidelines.