### PR TITLE
Replace http links with https

### DIFF
--- a/accounts.html
+++ b/accounts.html
@@ -66,7 +66,7 @@ muc.nick=smithy
         </section>
     </article>
     <footer>
-        <p class="matty">site designed by <a href="http://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
+        <p class="matty">site designed by <a href="https://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
     </footer>
 </body>
 

--- a/basic.html
+++ b/basic.html
@@ -2,6 +2,6 @@
 <head>
 </head>
 </body>
-<script>window.location = "http://profanity-im.github.io/guide/latest/basic.html";</script>
+<script>window.location = "https://profanity-im.github.io/guide/latest/basic.html";</script>
 </body>
 </html>

--- a/build.html
+++ b/build.html
@@ -2,6 +2,6 @@
 <head>
 </head>
 </body>
-<script>window.location = "http://profanity-im.github.io/guide/latest/build.html";</script>
+<script>window.location = "https://profanity-im.github.io/guide/latest/build.html";</script>
 </body>
 </html>

--- a/codeoverview.html
+++ b/codeoverview.html
@@ -2,6 +2,6 @@
 <head>
 </head>
 </body>
-<script>window.location = "http://profanity-im.github.io/guide/latest/codeoverview.html";</script>
+<script>window.location = "https://profanity-im.github.io/guide/latest/codeoverview.html";</script>
 </body>
 </html>

--- a/configuration.html
+++ b/configuration.html
@@ -2,6 +2,6 @@
 <head>
 </head>
 </body>
-<script>window.location = "http://profanity-im.github.io/reference.html";</script>
+<script>window.location = "https://profanity-im.github.io/reference.html";</script>
 </body>
 </html>

--- a/donate.html
+++ b/donate.html
@@ -7,7 +7,6 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Cache-Control" content="no-cache">
     <link href="css/profanity.css" type="text/css" rel="stylesheet">
-    
 </head>
 <body id="article">
     <img class="overlay" src="images/profanity_mouth-only.png" alt="Profanity Illustration">	
@@ -28,7 +27,7 @@
         </section>
     </article>
     <footer>
-        <p class="matty">site designed by <a href="http://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
+        <p class="matty">site designed by <a href="https://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
     </footer>
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -238,7 +238,7 @@
         </section>
     </article>
     <footer>
-        <p class="matty">site designed by <a href="http://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
+        <p class="matty">site designed by <a href="https://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
     </footer>
 </body>
 

--- a/files.html
+++ b/files.html
@@ -2,6 +2,6 @@
 <head>
 </head>
 </body>
-<script>window.location = "http://profanity-im.github.io/guide/latest/files.html";</script>
+<script>window.location = "https://profanity-im.github.io/guide/latest/files.html";</script>
 </body>
 </html>

--- a/guide/0100/build.html
+++ b/guide/0100/build.html
@@ -58,7 +58,7 @@ make install</code></pre>
                             <p>The latest code in <code>master</code> is also kept up to date with development changes
                                 to libmesode/libstrophe, so a manual build of this library may also be needed, see the
                                 <a target="_blank"
-                                    href="https://github.com/boothj5/libmesode/blob/master/README.markdown">README</a>
+                                    href="https://github.com/profanity-im/libmesode/blob/master/README.markdown">README</a>
                                 at libmesode.</p>
         </section>
         <section>
@@ -77,7 +77,7 @@ pkg-config</code></pre>
             <h4>Required dependencies:</h4>
 
             <p>Profanity can be built against either <a href="https://github.com/strophe/libstrophe"
-                    target="_blank">libstrophe</a>, or <a href="https://github.com/boothj5/libmesode"
+                    target="_blank">libstrophe</a>, or <a href="https://github.com/profanity-im/libmesode"
                     target="_blank">libmesode</a>. Libmesode has a few extra features around manual TLS certificate
                 verification. Version 0.6.0 (and above) of Profanity requires version 0.9.2 of libstrophe or libmesode.
             </p>

--- a/guide/0100/install.html
+++ b/guide/0100/install.html
@@ -131,7 +131,7 @@
                 </tr>
             </table>
             <p>To add to this list, submit a pull request to the <a
-                    href="https://github.com/boothj5/www_profanity_im/blob/master/install.html" target="_blank">website
+                    href="https://github.com/profanity-im/profanity-im.github.io/blob/master/install.html" target="_blank">website
                     source</a>, or email the <a href="https://lists.notraces.net/mailman/listinfo/profanity"
                     target="_blank">Mailing list</a> with details.</p>
         </section>

--- a/guide/0100/themes.html
+++ b/guide/0100/themes.html
@@ -38,7 +38,7 @@
 
             <p>Themes packaged with Profanity are installed to the system wide package data directory, for example:</p>
             <pre><code>/usr/local/share/profanity/themes</code></pre>
-            <p>User defined themes may be added to your user's <a href="files.html#themes-directory">themes directory</a>. If you'd like your theme to be added as a pre-packaged theme, feel free to submit a pull request at <a href="https://github.com/boothj5/profanity" target="_blank">Github</a>.</p>
+            <p>User defined themes may be added to your user's <a href="files.html#themes-directory">themes directory</a>. If you'd like your theme to be added as a pre-packaged theme, feel free to submit a pull request at <a href="https://github.com/profanity-im/profanity" target="_blank">Github</a>.</p>
 
             <p>A theme file contains two sections, <code>[colours]</code> and <code>[ui]</code>.</p>
             <p>The following properties are available in the <code>[colours]</code> section:</p>
@@ -431,7 +431,7 @@ bold_black
                 </tr>
             </table>
 
-            <p>Example themes can be found in the <a href="https://github.com/boothj5/profanity/tree/master/themes" target="_blank">themes folder</a> of the source code.</p>
+            <p>Example themes can be found in the <a href="https://github.com/profanity-im/profanity/tree/master/themes" target="_blank">themes folder</a> of the source code.</p>
         </section>
     </article>
     <footer>

--- a/guide/070/build.html
+++ b/guide/070/build.html
@@ -58,7 +58,7 @@ make install</code></pre>
                             <p>The latest code in <code>master</code> is also kept up to date with development changes
                                 to libmesode/libstrophe, so a manual build of this library may also be needed, see the
                                 <a target="_blank"
-                                    href="https://github.com/boothj5/libmesode/blob/master/README.markdown">README</a>
+                                    href="https://github.com/profanity-im/libmesode/blob/master/README.markdown">README</a>
                                 at libmesode.</p>
         </section>
         <section>
@@ -77,7 +77,7 @@ pkg-config</code></pre>
             <h4>Required dependencies:</h4>
 
             <p>Profanity can be built against either <a href="https://github.com/strophe/libstrophe"
-                    target="_blank">libstrophe</a>, or <a href="https://github.com/boothj5/libmesode"
+                    target="_blank">libstrophe</a>, or <a href="https://github.com/profanity-im/libmesode"
                     target="_blank">libmesode</a>. Libmesode has a few extra features around manual TLS certificate
                 verification. Version 0.6.0 (and above) of Profanity requires version 0.9.2 of libstrophe or libmesode.
             </p>

--- a/guide/070/install.html
+++ b/guide/070/install.html
@@ -124,7 +124,7 @@
                 </tr>
             </table>
             <p>To add to this list, submit a pull request to the <a
-                    href="https://github.com/boothj5/www_profanity_im/blob/master/install.html" target="_blank">website
+                    href="https://github.com/profanity-im/profanity-im.github.io/blob/master/install.html" target="_blank">website
                     source</a>, or email the <a href="https://lists.notraces.net/mailman/listinfo/profanity"
                     target="_blank">Mailing list</a> with details.</p>
         </section>

--- a/guide/070/themes.html
+++ b/guide/070/themes.html
@@ -38,7 +38,7 @@
 
             <p>Themes packaged with Profanity are installed to the system wide package data directory, for example:</p>
             <pre><code>/usr/local/share/profanity/themes</code></pre>
-            <p>User defined themes may be added to your user's <a href="files.html#themes-directory">themes directory</a>. If you'd like your theme to be added as a pre-packaged theme, feel free to submit a pull request at <a href="https://github.com/boothj5/profanity" target="_blank">Github</a>.</p>
+            <p>User defined themes may be added to your user's <a href="files.html#themes-directory">themes directory</a>. If you'd like your theme to be added as a pre-packaged theme, feel free to submit a pull request at <a href="https://github.com/profanity-im/profanity" target="_blank">Github</a>.</p>
 
             <p>A theme file contains two sections, <code>[colours]</code> and <code>[ui]</code>.</p>
             <p>The following properties are available in the <code>[colours]</code> section:</p>
@@ -431,7 +431,7 @@ bold_black
                 </tr>
             </table>
 
-            <p>Example themes can be found in the <a href="https://github.com/boothj5/profanity/tree/master/themes" target="_blank">themes folder</a> of the source code.</p>
+            <p>Example themes can be found in the <a href="https://github.com/profanity-im/profanity/tree/master/themes" target="_blank">themes folder</a> of the source code.</p>
         </section>
     </article>
     <footer>

--- a/guide/080/build.html
+++ b/guide/080/build.html
@@ -58,7 +58,7 @@ make install</code></pre>
                             <p>The latest code in <code>master</code> is also kept up to date with development changes
                                 to libmesode/libstrophe, so a manual build of this library may also be needed, see the
                                 <a target="_blank"
-                                    href="https://github.com/boothj5/libmesode/blob/master/README.markdown">README</a>
+                                    href="https://github.com/profanity-im/libmesode/blob/master/README.markdown">README</a>
                                 at libmesode.</p>
         </section>
         <section>
@@ -77,7 +77,7 @@ pkg-config</code></pre>
             <h4>Required dependencies:</h4>
 
             <p>Profanity can be built against either <a href="https://github.com/strophe/libstrophe"
-                    target="_blank">libstrophe</a>, or <a href="https://github.com/boothj5/libmesode"
+                    target="_blank">libstrophe</a>, or <a href="https://github.com/profanity-im/libmesode"
                     target="_blank">libmesode</a>. Libmesode has a few extra features around manual TLS certificate
                 verification. Version 0.6.0 (and above) of Profanity requires version 0.9.2 of libstrophe or libmesode.
             </p>

--- a/guide/080/install.html
+++ b/guide/080/install.html
@@ -131,7 +131,7 @@
                 </tr>
             </table>
             <p>To add to this list, submit a pull request to the <a
-                    href="https://github.com/boothj5/www_profanity_im/blob/master/install.html" target="_blank">website
+                    href="https://github.com/profanity-im/profanity-im.github.io/blob/master/install.html" target="_blank">website
                     source</a>, or email the <a href="https://lists.notraces.net/mailman/listinfo/profanity"
                     target="_blank">Mailing list</a> with details.</p>
         </section>

--- a/guide/080/themes.html
+++ b/guide/080/themes.html
@@ -38,7 +38,7 @@
 
             <p>Themes packaged with Profanity are installed to the system wide package data directory, for example:</p>
             <pre><code>/usr/local/share/profanity/themes</code></pre>
-            <p>User defined themes may be added to your user's <a href="files.html#themes-directory">themes directory</a>. If you'd like your theme to be added as a pre-packaged theme, feel free to submit a pull request at <a href="https://github.com/boothj5/profanity" target="_blank">Github</a>.</p>
+            <p>User defined themes may be added to your user's <a href="files.html#themes-directory">themes directory</a>. If you'd like your theme to be added as a pre-packaged theme, feel free to submit a pull request at <a href="https://github.com/profanity-im/profanity" target="_blank">Github</a>.</p>
 
             <p>A theme file contains two sections, <code>[colours]</code> and <code>[ui]</code>.</p>
             <p>The following properties are available in the <code>[colours]</code> section:</p>
@@ -431,7 +431,7 @@ bold_black
                 </tr>
             </table>
 
-            <p>Example themes can be found in the <a href="https://github.com/boothj5/profanity/tree/master/themes" target="_blank">themes folder</a> of the source code.</p>
+            <p>Example themes can be found in the <a href="https://github.com/profanity-im/profanity/tree/master/themes" target="_blank">themes folder</a> of the source code.</p>
         </section>
     </article>
     <footer>

--- a/guide/090/build.html
+++ b/guide/090/build.html
@@ -58,7 +58,7 @@ make install</code></pre>
                             <p>The latest code in <code>master</code> is also kept up to date with development changes
                                 to libmesode/libstrophe, so a manual build of this library may also be needed, see the
                                 <a target="_blank"
-                                    href="https://github.com/boothj5/libmesode/blob/master/README.markdown">README</a>
+                                    href="https://github.com/profanity-im/libmesode/blob/master/README.markdown">README</a>
                                 at libmesode.</p>
         </section>
         <section>
@@ -77,7 +77,7 @@ pkg-config</code></pre>
             <h4>Required dependencies:</h4>
 
             <p>Profanity can be built against either <a href="https://github.com/strophe/libstrophe"
-                    target="_blank">libstrophe</a>, or <a href="https://github.com/boothj5/libmesode"
+                    target="_blank">libstrophe</a>, or <a href="https://github.com/profanity-im/libmesode"
                     target="_blank">libmesode</a>. Libmesode has a few extra features around manual TLS certificate
                 verification. Version 0.6.0 (and above) of Profanity requires version 0.9.2 of libstrophe or libmesode.
             </p>

--- a/guide/090/install.html
+++ b/guide/090/install.html
@@ -131,7 +131,7 @@
                 </tr>
             </table>
             <p>To add to this list, submit a pull request to the <a
-                    href="https://github.com/boothj5/www_profanity_im/blob/master/install.html" target="_blank">website
+                    href="https://github.com/profanity-im/profanity-im.github.io/blob/master/install.html" target="_blank">website
                     source</a>, or email the <a href="https://lists.notraces.net/mailman/listinfo/profanity"
                     target="_blank">Mailing list</a> with details.</p>
         </section>

--- a/guide/090/themes.html
+++ b/guide/090/themes.html
@@ -38,7 +38,7 @@
 
             <p>Themes packaged with Profanity are installed to the system wide package data directory, for example:</p>
             <pre><code>/usr/local/share/profanity/themes</code></pre>
-            <p>User defined themes may be added to your user's <a href="files.html#themes-directory">themes directory</a>. If you'd like your theme to be added as a pre-packaged theme, feel free to submit a pull request at <a href="https://github.com/boothj5/profanity" target="_blank">Github</a>.</p>
+            <p>User defined themes may be added to your user's <a href="files.html#themes-directory">themes directory</a>. If you'd like your theme to be added as a pre-packaged theme, feel free to submit a pull request at <a href="https://github.com/profanity-im/profanity" target="_blank">Github</a>.</p>
 
             <p>A theme file contains two sections, <code>[colours]</code> and <code>[ui]</code>.</p>
             <p>The following properties are available in the <code>[colours]</code> section:</p>
@@ -431,7 +431,7 @@ bold_black
                 </tr>
             </table>
 
-            <p>Example themes can be found in the <a href="https://github.com/boothj5/profanity/tree/master/themes" target="_blank">themes folder</a> of the source code.</p>
+            <p>Example themes can be found in the <a href="https://github.com/profanity-im/profanity/tree/master/themes" target="_blank">themes folder</a> of the source code.</p>
         </section>
     </article>
     <footer>

--- a/guide/latest/build.html
+++ b/guide/latest/build.html
@@ -58,7 +58,7 @@ make install</code></pre>
                             <p>The latest code in <code>master</code> is also kept up to date with development changes
                                 to libmesode/libstrophe, so a manual build of this library may also be needed, see the
                                 <a target="_blank"
-                                    href="https://github.com/boothj5/libmesode/blob/master/README.markdown">README</a>
+                                    href="https://github.com/profanity-im/libmesode/blob/master/README.markdown">README</a>
                                 at libmesode.</p>
         </section>
         <section>
@@ -77,7 +77,7 @@ pkg-config</code></pre>
             <h4>Required dependencies:</h4>
 
             <p>Profanity can be built against either <a href="https://github.com/strophe/libstrophe"
-                    target="_blank">libstrophe</a>, or <a href="https://github.com/boothj5/libmesode"
+                    target="_blank">libstrophe</a>, or <a href="https://github.com/profanity-im/libmesode"
                     target="_blank">libmesode</a>. Libmesode has a few extra features around manual TLS certificate
                 verification. Version 0.6.0 (and above) of Profanity requires version 0.9.2 of libstrophe or libmesode.
             </p>

--- a/guide/latest/install.html
+++ b/guide/latest/install.html
@@ -131,7 +131,7 @@
                 </tr>
             </table>
             <p>To add to this list, submit a pull request to the <a
-                    href="https://github.com/boothj5/www_profanity_im/blob/master/install.html" target="_blank">website
+                    href="https://github.com/profanity-im/profanity-im.github.io/blob/master/install.html" target="_blank">website
                     source</a>, or email the <a href="https://lists.notraces.net/mailman/listinfo/profanity"
                     target="_blank">Mailing list</a> with details.</p>
         </section>

--- a/guide/latest/themes.html
+++ b/guide/latest/themes.html
@@ -38,7 +38,7 @@
 
             <p>Themes packaged with Profanity are installed to the system wide package data directory, for example:</p>
             <pre><code>/usr/local/share/profanity/themes</code></pre>
-            <p>User defined themes may be added to your user's <a href="files.html#themes-directory">themes directory</a>. If you'd like your theme to be added as a pre-packaged theme, feel free to submit a pull request at <a href="https://github.com/boothj5/profanity" target="_blank">Github</a>.</p>
+            <p>User defined themes may be added to your user's <a href="files.html#themes-directory">themes directory</a>. If you'd like your theme to be added as a pre-packaged theme, feel free to submit a pull request at <a href="https://github.com/profanity-im/profanity" target="_blank">Github</a>.</p>
 
             <p>A theme file contains two sections, <code>[colours]</code> and <code>[ui]</code>.</p>
             <p>The following properties are available in the <code>[colours]</code> section:</p>
@@ -431,7 +431,7 @@ bold_black
                 </tr>
             </table>
 
-            <p>Example themes can be found in the <a href="https://github.com/boothj5/profanity/tree/master/themes" target="_blank">themes folder</a> of the source code.</p>
+            <p>Example themes can be found in the <a href="https://github.com/profanity-im/profanity/tree/master/themes" target="_blank">themes folder</a> of the source code.</p>
         </section>
     </article>
     <footer>

--- a/helpout.html
+++ b/helpout.html
@@ -59,7 +59,7 @@
         </section>
     </article>
     <footer>
-        <p class="matty">site designed by <a href="http://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
+        <p class="matty">site designed by <a href="https://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
     </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -19,9 +19,9 @@
     </header>
     <div id="content">
         <h4>
-            Profanity is a console based XMPP client written in C using <a href="http://www.gnu.org/software/ncurses/"
-                target="_blank">ncurses</a> and <a href="http://strophe.im/libstrophe/" target="_blank">libstrophe</a>,
-            inspired&nbsp;by&nbsp;<a href="http://irssi.org/" target="_blank">Irssi</a>
+            Profanity is a console based XMPP client written in C using <a href="https://www.gnu.org/software/ncurses/"
+                target="_blank">ncurses</a> and <a href="https://strophe.im/libstrophe/" target="_blank">libstrophe</a>,
+            inspired&nbsp;by&nbsp;<a href="https://irssi.org/" target="_blank">Irssi</a>
         </h4>
 
         <p>
@@ -52,7 +52,7 @@
         </p>
 
         <p><b>Links:</b><br>
-            <a id="link-github" href="http://github.com/profanity-im/profanity" target="_blank">Github</a><br>
+            <a id="link-github" href="https://github.com/profanity-im/profanity" target="_blank">Github</a><br>
             <a id="link-mailinglist" href="https://lists.notraces.net/mailman/listinfo/profanity" target="_blank">Mailing
                 list</a><br>
             <a id="link-twitter" href="https://twitter.com/profanityim" target="_blank">Twitter</a><br>
@@ -88,7 +88,7 @@
     </div>
     <div id="Zoomer" style="overflow-y:auto"></div>
     <footer>
-        <p class="matty">site designed by <a href="http://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
+        <p class="matty">site designed by <a href="https://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
     </footer>
 </body>
 

--- a/install.html
+++ b/install.html
@@ -2,6 +2,6 @@
 <head>
 </head>
 </body>
-<script>window.location = "http://profanity-im.github.io/guide/latest/install.html";</script>
+<script>window.location = "https://profanity-im.github.io/guide/latest/install.html";</script>
 </body>
 </html>

--- a/issues.html
+++ b/issues.html
@@ -40,7 +40,7 @@
             <h3>Where to report issues</h3>
 
             <p>The best place to report issues is at the <a target="_blank"
-                    href="https://github.com/boothj5/profanity/issues">github issue tracker</a>.</p>
+                    href="https://github.com/profanity-im/profanity/issues">github issue tracker</a>.</p>
 	    <p>Other options are the <a target="_blank"
 		    href="https://lists.notraces.net/mailman/listinfo/profanity">mailing list</a>,
             <p>The following would be helpful in diagnosing/reproducing the issue if you can possibly supply it:

--- a/issues.html
+++ b/issues.html
@@ -131,7 +131,7 @@ make</code></pre>
         </section>
     </article>
     <footer>
-        <p class="matty">site designed by <a href="http://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
+        <p class="matty">site designed by <a href="https://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
     </footer>
 </body>
 

--- a/keybindings.html
+++ b/keybindings.html
@@ -2,6 +2,6 @@
 <head>
 </head>
 </body>
-<script>window.location = "http://profanity-im.github.io/guide/latest/keybindings.html";</script>
+<script>window.location = "https://profanity-im.github.io/guide/latest/keybindings.html";</script>
 </body>
 </html>

--- a/omemo.html
+++ b/omemo.html
@@ -2,6 +2,6 @@
 <head>
 </head>
 </body>
-<script>window.location = "http://profanity-im.github.io/guide/latest/omemo.html";</script>
+<script>window.location = "https://profanity-im.github.io/guide/latest/omemo.html";</script>
 </body>
 </html>

--- a/otr.html
+++ b/otr.html
@@ -2,6 +2,6 @@
 <head>
 </head>
 </body>
-<script>window.location = "http://profanity-im.github.io/guide/latest/otr.html";</script>
+<script>window.location = "https://profanity-im.github.io/guide/latest/otr.html";</script>
 </body>
 </html>

--- a/pgp.html
+++ b/pgp.html
@@ -2,6 +2,6 @@
 <head>
 </head>
 </body>
-<script>window.location = "http://profanity-im.github.io/guide/latest/pgp.html";</script>
+<script>window.location = "https://profanity-im.github.io/guide/latest/pgp.html";</script>
 </body>
 </html>

--- a/plugins.html
+++ b/plugins.html
@@ -252,7 +252,7 @@ enabled=active</code></pre>
         </section>
     </article>
     <footer>
-        <p class="matty">site designed by <a href="http://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
+        <p class="matty">site designed by <a href="https://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
     </footer>
 </body>
 

--- a/presence.html
+++ b/presence.html
@@ -2,6 +2,6 @@
 <head>
 </head>
 </body>
-<script>window.location = "http://profanity-im.github.io/guide/latest/presence.html";</script>
+<script>window.location = "https://profanity-im.github.io/guide/latest/presence.html";</script>
 </body>
 </html>

--- a/reference.html
+++ b/reference.html
@@ -2,6 +2,6 @@
 <head>
 </head>
 </body>
-<script>window.location = "http://profanity-im.github.io/guide/latest/reference.html";</script>
+<script>window.location = "https://profanity-im.github.io/guide/latest/reference.html";</script>
 </body>
 </html>

--- a/roomconf.html
+++ b/roomconf.html
@@ -2,6 +2,6 @@
 <head>
 </head>
 </body>
-<script>window.location = "http://profanity-im.github.io/guide/latest/roomconf.html";</script>
+<script>window.location = "https://profanity-im.github.io/guide/latest/roomconf.html";</script>
 </body>
 </html>

--- a/rooms.html
+++ b/rooms.html
@@ -2,6 +2,6 @@
 <head>
 </head>
 </body>
-<script>window.location = "http://profanity-im.github.io/guide/latest/rooms.html";</script>
+<script>window.location = "https://profanity-im.github.io/guide/latest/rooms.html";</script>
 </body>
 </html>

--- a/subscriptions.html
+++ b/subscriptions.html
@@ -2,6 +2,6 @@
 <head>
 </head>
 </body>
-<script>window.location = "http://profanity-im.github.io/guide/latest/subscriptions.html";</script>
+<script>window.location = "https://profanity-im.github.io/guide/latest/subscriptions.html";</script>
 </body>
 </html>

--- a/themes.html
+++ b/themes.html
@@ -2,6 +2,6 @@
 <head>
 </head>
 </body>
-<script>window.location = "http://profanity-im.github.io/guide/latest/themes.html";</script>
+<script>window.location = "https://profanity-im.github.io/guide/latest/themes.html";</script>
 </body>
 </html>

--- a/userguide.html
+++ b/userguide.html
@@ -32,7 +32,7 @@
         </section>
     </article>
     <footer>
-        <p class="matty">site designed by <a href="http://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
+        <p class="matty">site designed by <a href="https://www.matthewbalaam.co.uk">Matthew Balaam</a></p>
     </footer>
 </body>
 


### PR DESCRIPTION
I would like to do some under the hood cleanup of the webpage. 

- [ ] Replace http with https, there should be no unencrypted web traffic anymore
- [ ] Refactor code to comply with coding style guidlines like [1](https://www.w3schools.com/html/html5_syntax.asp), [2](https://developers.google.com/style/html-formatting), [3](https://google.github.io/styleguide/htmlcssguide.html)


