### PR TITLE
Add shared-mime-info as an optional dependency to build guide

### DIFF
--- a/guide/0100/build.html
+++ b/guide/0100/build.html
@@ -99,7 +99,8 @@ libsignal-protocol-c-dev # OMEMO support
 libgcrypt-dev            # OMEMO support (>= 1.7)
 libgtk2.0-dev            # Desktop tray icon support
 python-dev               # Python plugin support
-libcmocka-dev            # To run tests</code></pre>
+libcmocka-dev            # To run tests
+shared-mime-info         # Send files with the correct mime type</code></pre>
         </section>
         <section>
             <a name="distrodeps"></a>

--- a/guide/0110/build.html
+++ b/guide/0110/build.html
@@ -99,7 +99,8 @@ libsignal-protocol-c-dev # OMEMO support
 libgcrypt-dev            # OMEMO support (>= 1.7)
 libgtk2.0-dev            # Desktop tray icon support
 python-dev               # Python plugin support
-libcmocka-dev            # To run tests</code></pre>
+libcmocka-dev            # To run tests
+shared-mime-info         # Send files with the correct mime type</code></pre>
         </section>
         <section>
             <a name="distrodeps"></a>

--- a/guide/0111/build.html
+++ b/guide/0111/build.html
@@ -99,7 +99,8 @@ libsignal-protocol-c-dev # OMEMO support
 libgcrypt-dev            # OMEMO support (>= 1.7)
 libgtk2.0-dev            # Desktop tray icon support
 python-dev               # Python plugin support
-libcmocka-dev            # To run tests</code></pre>
+libcmocka-dev            # To run tests
+shared-mime-info         # Send files with the correct mime type</code></pre>
         </section>
         <section>
             <a name="distrodeps"></a>

--- a/guide/0120/build.html
+++ b/guide/0120/build.html
@@ -91,7 +91,8 @@ libsignal-protocol-c     # OMEMO support
 libgcrypt                # OMEMO support (>= 1.7)
 gtk2 or gtk3             # Desktop tray icon support
 python                   # Python plugin support
-cmocka                   # To run tests</code></pre>
+cmocka                   # To run tests
+shared-mime-info         # Send files with the correct mime type</code></pre>
         </section>
         <section>
             <a name="distrodeps"></a>

--- a/guide/070/build.html
+++ b/guide/070/build.html
@@ -98,7 +98,8 @@ libsignal-protocol-c-dev # OMEMO support
 libgcrypt-dev            # OMEMO support (>= 1.7)
 libgtk2.0-dev            # Desktop tray icon support
 python-dev               # Python plugin support
-libcmocka-dev            # To run tests</code></pre>
+libcmocka-dev            # To run tests
+shared-mime-info         # Send files with the correct mime type</code></pre>
         </section>
         <section>
             <a name="distrodeps"></a>

--- a/guide/080/build.html
+++ b/guide/080/build.html
@@ -98,7 +98,8 @@ libsignal-protocol-c-dev # OMEMO support
 libgcrypt-dev            # OMEMO support (>= 1.7)
 libgtk2.0-dev            # Desktop tray icon support
 python-dev               # Python plugin support
-libcmocka-dev            # To run tests</code></pre>
+libcmocka-dev            # To run tests
+shared-mime-info         # Send files with the correct mime type</code></pre>
         </section>
         <section>
             <a name="distrodeps"></a>

--- a/guide/090/build.html
+++ b/guide/090/build.html
@@ -99,7 +99,8 @@ libsignal-protocol-c-dev # OMEMO support
 libgcrypt-dev            # OMEMO support (>= 1.7)
 libgtk2.0-dev            # Desktop tray icon support
 python-dev               # Python plugin support
-libcmocka-dev            # To run tests</code></pre>
+libcmocka-dev            # To run tests
+shared-mime-info         # Send files with the correct mime type</code></pre>
         </section>
         <section>
             <a name="distrodeps"></a>

--- a/guide/latest/build.html
+++ b/guide/latest/build.html
@@ -91,7 +91,8 @@ libsignal-protocol-c     # OMEMO support
 libgcrypt                # OMEMO support (>= 1.7)
 gtk2 or gtk3             # Desktop tray icon support
 python                   # Python plugin support
-cmocka                   # To run tests</code></pre>
+cmocka                   # To run tests
+shared-mime-info         # Send files with the correct mime type</code></pre>
         </section>
         <section>
             <a name="distrodeps"></a>


### PR DESCRIPTION
This addresses https://github.com/profanity-im/profanity/issues/967

If `shared-mime-info` isn't installed profanity will send out almost all files as `application/octet-stream` which causes some servers (most notably recent prosody versions) to set a `Content-Disposition: attachement;` header, even for images. This causes users to need to save a file in order to display it rather than be able to view it in the browser.